### PR TITLE
[REFACT] MDC를 활용하여 로그 뒤섞임 방지하기 ♻️ 

### DIFF
--- a/src/main/java/com/wekids/backend/log/filter/MDCLoggingFilter.java
+++ b/src/main/java/com/wekids/backend/log/filter/MDCLoggingFilter.java
@@ -1,0 +1,23 @@
+package com.wekids.backend.log.filter;
+
+import jakarta.servlet.*;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MDCLoggingFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        final UUID uuid = UUID.randomUUID();
+        MDC.put("request_id", uuid.toString());
+        chain.doFilter(request, response);
+        MDC.clear();
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="30 seconds">
-
     <!-- INFO 로그 파일 설정 -->
     <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./logs/info/info-%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -20,7 +18,7 @@
     <!-- WARN 로그 파일 설정 -->
     <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./logs/warn/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -36,7 +34,7 @@
     <!-- ERROR 로그 파일 설정 -->
     <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./logs/error/error-%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -52,7 +50,7 @@
     <!-- ALL 로그 파일 설정 -->
     <appender name="ALL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./logs/all/all-%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -63,7 +61,7 @@
     <!-- 콘솔 출력 Appender 설정 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
# 📄 Work Description
- 기존에 로그를 기록하는 방법은 로그 뒤섞임 문제가 있음
- 따라서, MDC를 활용하여 고유의 ID를 지정하여 구분할 수 있게 변경

# ⚙️ ISSUE
- closed #89


# 📷 Screenshot
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/c9d45841-9673-4d8b-bca5-9d34c9bae64c" />



# 💬 To Reviewers
[여기 블로그 참고햇습니당](https://mangkyu.tistory.com/266)
